### PR TITLE
Handling frequency slider inside bottom sheet

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -723,6 +723,8 @@ export class ScrollBottomSheet<T extends any> extends Component<Props<T>> {
           ref={this.drawerContentRef}
           simultaneousHandlers={[this.scrollComponentRef, this.masterDrawer]}
           shouldCancelWhenOutside={false}
+          activeOffsetY={[-1, 1]} 
+          failOffsetX={[-5, 5]}
           onGestureEvent={this.onDrawerGestureEvent}
           onHandlerStateChange={this.onDrawerGestureEvent}
         >


### PR DESCRIPTION
When using slider like components inside the bottom sheet the parent bottom sheet gesture handler takes over. We needed to prevent this, thus I have added some props to disable that activation.